### PR TITLE
Add Squeeze and Excitation block

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -38,6 +38,13 @@ class TestNN(TestCase):
             self.assertEqual(contrib_F.film(inp, half_ones_half_zeros, half_ones_half_neg_ones), output)
             self.assertEqual(output.sum(), inp[:, :5].sum())
 
+    def test_se(self):
+        se = contrib_nn.SE(16)
+        input_16_ch = torch.randn(1, 16, 4, 4, requires_grad=True)
+        output = se(input_16_ch)
+
+        self.assertGradAndGradgradChecks(lambda x: se(x), (input_16_ch,))
+        self.assertEqual(se(input_16_ch), output)
 
 if __name__ == '__main__':
     run_tests()

--- a/torchcontrib/nn/modules/__init__.py
+++ b/torchcontrib/nn/modules/__init__.py
@@ -1,3 +1,3 @@
-from .linear import FiLM
+from .linear import FiLM, SE
 
-__all__ = ['FiLM']
+__all__ = ['FiLM', 'SE']

--- a/torchcontrib/nn/modules/linear.py
+++ b/torchcontrib/nn/modules/linear.py
@@ -1,7 +1,10 @@
 import torch
-from torch.nn import Module
-from .. import functional as F
 
+import torch.nn as nn
+from torch.nn import Module
+
+import torch.nn.functional as functional
+from .. import functional as F
 
 class FiLM(Module):
     r"""Applies Feature-wise Linear Modulation to the incoming data as described
@@ -34,3 +37,42 @@ class FiLM(Module):
     """
     def forward(self, input, gamma, beta):
         return F.film(input, gamma, beta)
+
+# partially from https://www.kaggle.com/c/tgs-salt-identification-challenge/discussion/65939
+class SE(Module):
+    r"""Applies Squeeze and Excitation to the incoming data as described
+    in the paper `Squeeze-and-Excitation Networks`_.
+    
+    Args:
+        in_ch (int): Number of channels in the input tensor
+        r (int): Reduction ratio of the SE block. Default: 16
+
+    Shape:
+        - Input: :math:`(N, C, H, W)`
+        - Output: :math:`(N, C, H, W)`, same shape as input
+
+    Examples::
+        >>> input = torch.randn(1, 3, 256, 256)
+        >>> se = SE(in_ch=3, r=16)
+        >>> out = se(input)
+        >>> out.size()
+        torch.Size([1, 3, 256, 256])
+    """
+    def __init__(self, in_ch, r=16):
+        super(SE, self).__init__()
+        
+        self.linear_1 = nn.Linear(in_ch, in_ch//r)
+        self.linear_2 = nn.Linear(in_ch//r, in_ch)
+    
+    def forward(self, x):
+        input_x = x
+
+        x = x.view(*(x.shape[:-2]),-1).mean(-1)
+        x = functional.relu(self.linear_1(x), inplace=True)
+        x = self.linear_2(x)
+        x = x.unsqueeze(-1).unsqueeze(-1)
+        x = torch.sigmoid(x)
+
+        x = torch.mul(input_x, x)
+        
+        return x


### PR DESCRIPTION
Hi,

I added the squeeze and excitation block from the Squeeze-and-Excitation Networks [paper](https://arxiv.org/abs/1709.01507).

The code for the SE block is in ` torchcontrib/nn/modules/linear.py` and the tests for it are in ` test/test_nn.py`