### PR TITLE
Fix missing SWA "defaults" attribute

### DIFF
--- a/torchcontrib/optim/swa.py
+++ b/torchcontrib/optim/swa.py
@@ -110,6 +110,7 @@ class SWA(Optimizer):
 
         self.optimizer = optimizer
 
+        self.defaults = self.optimizer.defaults
         self.param_groups = self.optimizer.param_groups
         self.state = defaultdict(dict)
         self.opt_state = self.optimizer.state


### PR DESCRIPTION
When trying to use an SWA-wrapped SGD optimizer with `torch.optim.lr_scheduler.CyclicLR` (PyTorch 1.1.0), I get an
`AttributeError: 'SWA' object has no attribute 'defaults'` from this line: https://github.com/pytorch/pytorch/blob/af6eea93910723c89cad619f350e2cce3d23fc22/torch/optim/lr_scheduler.py#L587.

This can be easily fixed by (a) adding the missing `defaults` attribute to `SWA` in its constructor, as I've done in this PR. Or maybe a more pythonic fix would be to (b) add the missing call to the super constructor at the end of `SWA.__init__()`, something like

    super(SWA, self).__init__(self.optimizer.params, self.optimizer.defaults)

What do you think?