### PR TITLE
Make test a module, fix import from common

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4,7 +4,7 @@ import torchcontrib
 import torchcontrib.nn as contrib_nn
 import torchcontrib.nn.functional as contrib_F
 from torch.autograd import gradcheck, gradgradcheck
-from common import run_tests, TestCase
+from .common import run_tests, TestCase
 
 
 class TestNN(TestCase):

--- a/test/test_swa.py
+++ b/test/test_swa.py
@@ -7,7 +7,7 @@ from torch import sparse
 from torch import optim
 from torch import nn
 import torchcontrib.optim as contriboptim
-from common import TestCase, run_tests
+from .common import TestCase, run_tests
 from torch.utils import data
 
 


### PR DESCRIPTION
Previously, `from common import` would fail with an `ImportError` in some test environments. This fixed that.