### PR TITLE
Add modules for easily constructing residual networks

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,5 +1,6 @@
 import unittest
 import torch
+from torch import nn
 import torchcontrib
 import torchcontrib.nn as contrib_nn
 import torchcontrib.nn.functional as contrib_F
@@ -37,6 +38,22 @@ class TestNN(TestCase):
             output = m(inp, half_ones_half_zeros, half_ones_half_neg_ones)
             self.assertEqual(contrib_F.film(inp, half_ones_half_zeros, half_ones_half_neg_ones), output)
             self.assertEqual(output.sum(), inp[:, :5].sum())
+
+    def test_residual_block(self):
+        net = contrib_nn.ResidualBlock(nn.ReLU(inplace=True))
+        input = torch.tensor([-2., -1., 0., 1., 2.])
+        expected = torch.tensor([-2., -1., 0., 2., 4.])
+        self.assertEqual(net(input), expected)
+
+    def test_residual_block_with_shortcut(self):
+        net = contrib_nn.ResidualBlockWithShortcut(
+            nn.ReLU(inplace=True),
+            nn.AvgPool1d(2),
+            shortcut=nn.AvgPool1d(2),
+        )
+        input = torch.tensor([[[-2., 0., 0., 2.]]])
+        expected = torch.tensor([[[-1., 2.]]])
+        self.assertEqual(net(input), expected)
 
 
 if __name__ == '__main__':

--- a/torchcontrib/nn/modules/__init__.py
+++ b/torchcontrib/nn/modules/__init__.py
@@ -1,3 +1,4 @@
 from .linear import FiLM
+from .residual import ResidualBlock, ResidualBlockWithShortcut
 
-__all__ = ['FiLM']
+__all__ = ['FiLM', 'ResidualBlock', 'ResidualBlockWithShortcut']

--- a/torchcontrib/nn/modules/residual.py
+++ b/torchcontrib/nn/modules/residual.py
@@ -1,0 +1,98 @@
+from torch import nn
+
+
+class ResidualBlock(nn.Sequential):
+    r"""A residual block with an identity shortcut connection.
+
+    As in :class:`~torch.nn.Sequential`, modules will be added to it in the
+    order they are passed in the constructor, and an :class:`OrderedDict` can be
+    passed instead. The final module's output will be added to the original
+    input and returned. The input and output must be :ref:`broadcastable
+    <broadcasting-semantics>`.
+
+    Here is an example MNIST classifier::
+
+        model = nn.Sequential(
+            nn.Conv2d(1, 10, 1),
+            ResidualBlock(
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+            ),
+            nn.MaxPool2d(2),
+            ResidualBlock(
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, padding=1),
+            ),
+            nn.MaxPool2d(2),
+            nn.Flatten(),
+            nn.Linear(7*7*10, 10),
+            nn.LogSoftmax(dim=-1),
+        )
+
+    See: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual
+    Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and
+    "Identity Mappings in Deep Residual Networks"
+    (https://arxiv.org/abs/1603.05027).
+    """
+
+    def forward(self, input):
+        output = input.clone()
+        for module in self:
+            output = module(output)
+        return input + output
+
+
+class ResidualBlockWithShortcut(nn.ModuleDict):
+    r"""A residual block with a non-identity shortcut connection.
+
+    As in :class:`~torch.nn.Sequential`, modules will be added to the 'main'
+    branch in the order they are passed in the constructor, and an
+    :class:`OrderedDict` can be passed instead. The :attr:`shortcut` keyword
+    argument specifies a module that performs the mapping for the shortcut
+    connection.  The output of the 'main' branch will be added to the output of
+    the 'shortcut' branch and returned. They must be :ref:`broadcastable
+    <broadcasting-semantics>`.
+
+    This module is useful where the 'main' branch has an output shape that is
+    different from its input shape, so :class:`ResidualBlock` cannot
+    be used. The shortcut mapping may be used to adjust the shape of the input
+    to match. Here is an example MNIST classifier::
+
+        model = nn.Sequential(
+            ResidualBlockWithShortcut(
+                nn.Conv2d(1, 10, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(10, 10, 3, stride=2, padding=1),
+                shortcut=nn.Conv2d(1, 10, 1, stride=2, bias=False),
+            ),
+            ResidualBlockWithShortcut(
+                nn.ReLU(),
+                nn.Conv2d(10, 20, 3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(20, 20, 3, stride=2, padding=1),
+                shortcut=nn.Conv2d(10, 20, 1, stride=2, bias=False),
+            ),
+            nn.Flatten(),
+            nn.Linear(7*7*20, 10),
+            nn.LogSoftmax(dim=-1),
+        )
+
+    See: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual
+    Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and
+    "Identity Mappings in Deep Residual Networks"
+    (https://arxiv.org/abs/1603.05027).
+    """
+
+    def __init__(self, *args, shortcut=nn.Identity()):
+        super().__init__()
+        self['main'] = nn.Sequential(*args)
+        self['shortcut'] = shortcut
+
+    def forward(self, input):
+        output_main = self['main'](input.clone())
+        output_shortcut = self['shortcut'](input)
+        return output_main + output_shortcut


### PR DESCRIPTION
Here are two modules that implement residual blocks in a nice object-oriented way. They subclass the container modules, and they accept modules as positional arguments similarly to `nn.Sequential`. They also pretty-print nicely, again due to subclassing the container modules. No more self-implemented convoluted logic in separately-defined `__init__()` and `forward()`

The `ResidualBlock` module just takes a sequence of modules and adds a 'shortcut connection' between its input and its output. In other words its final output is the sum of the output of its last module and its original input. I also provide a `ResidualBlockWithShortcut` module, which lets you customize the shortcut connection, for instance to make sure it is the same shape as the output of the main branch.

No more self-implemented convoluted easily-gotten-wrong network topology in separately-defined `__init__()` and `forward()` methods, when all you want is a standard ResNet! The code looks like this:

```python
model = nn.Sequential(
    nn.Conv2d(1, 10, 1),
    ResidualBlock(
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
    ),
    nn.MaxPool2d(2),
    ResidualBlock(
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
        nn.ReLU(),
        nn.Conv2d(10, 10, 3, padding=1),
    ),
    nn.MaxPool2d(2),
    nn.Flatten(),
    nn.Linear(7*7*10, 10),
    nn.LogSoftmax(dim=-1),
)
```

and the model looks like this when printed:

```
Sequential(
  (0): Conv2d(1, 10, kernel_size=(1, 1), stride=(1, 1))
  (1): ResidualBlock(
    (0): ReLU()
    (1): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (2): ReLU()
    (3): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
  )
  (2): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
  (3): ResidualBlock(
    (0): ReLU()
    (1): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    (2): ReLU()
    (3): Conv2d(10, 10, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
  )
  (4): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
  (5): Flatten()
  (6): Linear(in_features=490, out_features=10, bias=True)
  (7): LogSoftmax()
)
```

The references for residual blocks are: Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun, "Deep Residual Learning for Image Recognition" (https://arxiv.org/abs/1512.03385), and "Identity Mappings in Deep Residual Networks" (https://arxiv.org/abs/1603.05027).
