### PR TITLE
Don't try to use CuDNN attributes without confirming CUDA is available

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -29,7 +29,8 @@ import torch.backends.mkl
 
 
 torch.set_default_tensor_type('torch.DoubleTensor')
-torch.backends.cudnn.disable_global_flags()
+if torch.cuda.is_available():
+    torch.backends.cudnn.disable_global_flags()
 
 
 parser = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
`torch.backends.cudnn.disable_global_flags()` ([this line of code here](https://github.com/pytorch/contrib/blob/master/test/common.py#L32)) gives an error when it is run on a machine without CUDA:

```
AttributeError: module 'torch.backends.cudnn' has no attribute 'disable_global_flags'
```

and all test cases fail. I put it behind an `if torch.cuda.is_available()` test. I am now able to run PyTorch Contrib's test cases on my GPU-less laptop. I think your Travis CI checks have also been failing due to this error, as well.